### PR TITLE
Remove the somewhat jarring tagline from the hurricane response site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -16,7 +16,7 @@
 title: Code for America Hurricane Response
 email: email@hurricane-response.org
 description: >- # this means to ignore newlines until "baseurl:"
-  No One's Coming - It's Up to Us
+  Homepage for Code for America's Hurricane Response efforts
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "https://www.hurricane-response.org" # the base hostname & protocol for your site, e.g. http://example.com
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to the CFA response theme. Please provide information about the changes: What issue they fix, how they solve the issue, and why the solution works. -->

## Description
<!-- Please describe your pull request. -->
It was pointed out in Slack that the phrase "No one's coming" is a bit jarring for a hurricane response site. Removed it here, and we should probably remove it from our other sites, and make the description on each say what the site is.
## List of changes
<!-- Please describe what was changed/added. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Content change (no code modified)

## Checklist:
- [ ] This pull request relates to a ticket.
- [ ] This code is tested.
- [x] I want my code added to the response theme. (And all other response sites we do.)